### PR TITLE
Exclude the 'dirvish' filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ set, it will fall back to `g:lengthmatters_start_at_column`.
 
 (defaults to
 `['unite', 'tagbar', 'startify', 'gundo', 'vimshell', 'w3m',
-'nerdtree', 'help', 'qf']`)  
+'nerdtree', 'help', 'qf', 'dirvish']`)  
 
 A list of **filetypes** for which the highlighting isn't (and can't be) enabled.
 

--- a/doc/lengthmatters.txt
+++ b/doc/lengthmatters.txt
@@ -95,7 +95,8 @@ A list of filetypes for which the highlighting isn't (and can't be) enabled.
     'w3m',
     'nerdtree',
     'help',
-    'qf'
+    'qf',
+    'dirvish'
   ]
 
 -----------------------------------------------------------------------------

--- a/plugin/lengthmatters.vim
+++ b/plugin/lengthmatters.vim
@@ -42,7 +42,7 @@ call s:Default('match_name', 'OverLength')
 call s:Default('highlight_command', s:DefaultHighlighting())
 call s:Default('excluded', [
       \   'unite', 'tagbar', 'startify', 'gundo', 'vimshell', 'w3m',
-      \   'nerdtree', 'help', 'qf'
+      \   'nerdtree', 'help', 'qf', 'dirvish'
       \ ])
 call s:Default('exclude_readonly', 1)
 


### PR DESCRIPTION
This is for the netrw replacement plugin called 'dirvish':
<https://github.com/justinmk/vim-dirvish/>

I saw that the list of default excludes included a few popular plugins. This commit adds yet one.