### PR TITLE
Not working inside specific buffers alone

### DIFF
--- a/plugin/lengthmatters.vim
+++ b/plugin/lengthmatters.vim
@@ -57,6 +57,8 @@ endfunction
 " match of the current buffer if available, unless the textwidth has changed. If
 " it has, force a reload by disabling the highlighting and re-enabling it.
 function! s:Enable()
+  let w:lengthmatters_active = 1
+
   " Do nothing if this is an excluded filetype.
   if s:ShouldBeDisabled() | return | endif
 
@@ -67,10 +69,10 @@ function! s:Enable()
   " time.
   if s:ShouldUseTw() && s:TwChanged()
     call s:Disable()
+    let w:lengthmatters_active = 1
     let w:lengthmatters_tw = &tw
   endif
 
-  let w:lengthmatters_active = 1
   call s:Highlight()
 
   " Create a new match if it doesn't exist already (in order to avoid creating
@@ -141,10 +143,16 @@ endfunction
 " script). It disables the highlighting on the excluded filetypes and enables it
 " if it wasn't enabled/disabled before or if there's a new textwidth.
 function! s:AutocmdTrigger()
-  if index(g:lengthmatters_excluded, &ft) >= 0
-    call s:Disable()
-  elseif !exists('w:lengthmatters_active') && g:lengthmatters_on_by_default
-        \ || (s:ShouldUseTw() && s:TwChanged())
+  if !exists('w:lengthmatters_active')
+    if g:lengthmatters_on_by_default
+      call s:Enable()
+    endif
+  elseif index(g:lengthmatters_excluded, &ft) >= 0
+    if w:lengthmatters_active
+      call s:Disable()
+      let w:lengthmatters_active = 1
+    endif
+  elseif w:lengthmatters_active
     call s:Enable()
   endif
 endfunction

--- a/test/lengthmatters.vader
+++ b/test/lengthmatters.vader
@@ -48,17 +48,6 @@ Execute (LengthmattersDisable deletes a match if present):
   AssertEqual number_of_matches, len(getmatches())
 
 
-Execute (Lengthmatter is inactive in the excluded filetypes):
-  let g:lengthmatters_excluded = ['foobar']
-
-  set filetype=foobar
-  Assert !w:lengthmatters_active
-
-  LengthmattersDisable
-  LengthmattersEnable
-  Assert !w:lengthmatters_active
-
-
 Execute (highlighting can be forced using colors):
   let id = hlID(g:lengthmatters_match_name)
   call lengthmatters#highlight('cterm=bold ctermfg=10 ctermbg=11 guibg=#000000')


### PR DESCRIPTION
Per docs I expected activation was per buffer but whenever I open a file that activates it and then switch to a buffer where it **wasn't** previously activated, it stays active.

My configuration on `.vimrc` is this:

```vim
" lengthmatters Setup {{{
let g:lengthmatters_on_by_default = 0
call lengthmatters#highlight_link_to('Visual')
au FileType c,cpp,go :LengthmattersEnable
" }}}
```

Is there any way to have it activated solely for those file types?

Strangely this configuration enables lenghmatters even when opening a file whose file type is not in that list. This happens for example, when I open a `.swift` file it's disabled, then I open my `.vimrc` and it gets enabled.

## UPDATE

My configuration is like this now instead:

```vim
" lengthmatters Setup {{{
let g:lengthmatters_match_name = 'Visual'
let g:lengthmatters_excluded = [
    \ '', 'qf', 'help', 'unite', 'tagbar', 'gundo', 'vimshell', 'vimfiler',
    \ 'quickrun', 'python', 'html', 'javascript', 'css', 'scss', 'latex',
    \ 'haskell', 'purescript', 'elm'
    \ ]
" }}}
```