### PR TITLE
Refactor to make use of extracted function

### DIFF
--- a/plugin/lengthmatters.vim
+++ b/plugin/lengthmatters.vim
@@ -147,7 +147,7 @@ function! s:AutocmdTrigger()
     if g:lengthmatters_on_by_default
       call s:Enable()
     endif
-  elseif index(g:lengthmatters_excluded, &ft) >= 0
+  elseif s:ShouldBeDisabled()
     if w:lengthmatters_active
       call s:Disable()
       let w:lengthmatters_active = 1


### PR DESCRIPTION
The resolution on #14 was not benefiting the existence of
s:ShouldBeDisabled(). This is a refactor to do so and as well
may resolve #13.